### PR TITLE
train/test split, CNN/LSTM policies, baselines, sentiment prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,234 +1,278 @@
-# LLM-sentiment enhanced RL framework for portfolio management in French stock market
+# LLM-Sentiment Enhanced RL for Portfolio Management (CAC 40)
 
 ## Project Overview
 
-This repository implements a **reinforcement learning (RL)** based portfolio management framework for the French equity market (CAC 40), enhanced with sentiment signals extracted from French financial news via large language models (LLMs).  The primary algorithm is **Proximal Policy Optimization (PPO)**.  Sentiment integration is optional and can be toggled for ablation.
+This repository implements a **reinforcement learning (RL)** portfolio management framework for the French equity market (CAC 40), enhanced with optional sentiment signals extracted from French financial news via large language models.
 
-**Key contributions:**
+The core algorithm is **Proximal Policy Optimization (PPO)** with pluggable policy architectures (MLP, CNN, LSTM). Sentiment integration is toggled via configuration for clean ablation studies.
 
-* End-to-end pipeline from data ingestion (prices + news) to RL training & evaluation
-* Reproducible environment using Conda, GitHub, and best practices
-* Clear separation of raw vs processed data, code modules, and notebooks
-* Statistical evaluation of model performance (Sharpe ratio, drawdown, Welch’s t-test)
+**Key features:**
 
----
-
-## Table of Contents
-
-1. [Repository Structure](#repository-structure)
-2. [Dependencies & Environment Setup](#dependencies--environment-setup)
-3. [Data Acquisition](#data-acquisition)
-4. [Data Preprocessing](#data-preprocessing)
-5. [Training the PPO Agent](#training-the-ppo-agent)
-6. [Evaluation](#evaluation)
-7. [Extending with Sentiment](#extending-with-sentiment)
-8. [Reproducibility & CI](#reproducibility--ci)
-9. [Project Roadmap](#project-roadmap)
-10. [Contributing](#contributing)
-11. [License](#license)
+* End-to-end pipeline: data ingestion, preprocessing, RL training, out-of-sample evaluation
+* Temporal train/test split (default: train 2018-2022, test 2023-2024) to prevent look-ahead bias
+* Classical baselines (equal-weight, buy-and-hold, inverse-volatility) for rigorous comparison
+* CNN and LSTM policy architectures that exploit the temporal structure of observations
+* French-language sentiment via CamemBERT (with FinBERT fallback for comparison)
+* Multi-seed training for statistical significance
+* CI via GitHub Actions
 
 ---
 
 ## Repository Structure
 
 ```text
-fr_sent_ml/
+LLM_in_portfoliomanagement/
 │
 ├── data/
-│   ├── raw/                 # Raw CSVs & Parquet files (prices, news archives)
-│   ├── processed/           # Cleaned, merged datasets (e.g., returns, sentiment)
-│   └── preprocessed/        # Final data for modeling (parquet, CSV)
+│   ├── raw/                     # Per-ticker CSVs from Yahoo Finance
+│   ├── preprocessed/            # Cleaned parquet files (prices, features)
+│   ├── sample/                  # Minimal 2-asset sample for quick tests
+│   └── download_prices.py       # Download CAC 40 price data
 │
-├── notebooks/              # Jupyter notebooks for EDA & preprocessing
-│   └── 01_prepare_data.ipynb
+├── environment/
+│   └── portfolio_env.py         # Custom Gymnasium environment
 │
-├── src/                    # Source code modules
-│   ├── data/               # Scripts to download & preprocess data
-│   │   └── download_prices.py
-│   ├── sentiment/          # Sentiment extraction wrappers (GPT-4 prompts)
-│   ├── rl_agent/           # Environment + PPO training & evaluation
-│   │   ├── portfolio_env.py
-│   │   ├── train_ppo.py
-│   │   └── eval_ppo.py
-│   ├── utils/              # Utility functions (logging, seeding, config)
-│   └── config.yaml         # Hyperparameters and paths
+├── src/
+│   ├── rl_agent/
+│   │   ├── train_ppo.py         # PPO training (split, policy select, multi-seed)
+│   │   ├── eval_ppo.py          # Full evaluation with metrics & visualization
+│   │   ├── eval_ppo_debug.py    # Debug variant with timeouts & diagnostics
+│   │   ├── baselines.py         # Classical portfolio baselines
+│   │   ├── custom_policies.py   # CNN / LSTM feature extractors for SB3
+│   │   └── visualizations.py    # Plotting utilities
+│   └── sentiment/
+│       └── extract_sentiment.py # CamemBERT / FinBERT sentiment pipeline
 │
-├── models/                 # Saved model checkpoints & HF Hub links
-├── .github/                # CI workflows (lint, tests)
-├── environment.yml         # Conda environment specification
-├── requirements.txt        # pip fallback for specific packages
-├── .gitignore
-├── README.md               # ← You are here
-└── LICENSE
+├── notebooks/
+│   ├── 01_prepare_data.ipynb    # Raw data → preprocessed parquet
+│   ├── convert_data_returns.ipynb
+│   └── create_sample.ipynb      # Create minimal sample dataset
+│
+├── tests/                       # pytest suite
+│   ├── test_portfolio_env.py
+│   ├── test_train_ppo_integration.py
+│   ├── test_eval_ppo.py
+│   └── test_model_loading.py
+│
+├── models/                      # Saved model checkpoints (timestamped)
+├── logs/                        # TensorBoard logs & monitor CSVs
+├── results/                     # Evaluation outputs
+│
+├── environment.yml              # Conda environment specification
+├── config_minimal.yaml          # Minimal config for quick testing
+├── .github/workflows/conda-tests.yml
+├── LICENSE                      # MIT
+└── README.md
 ```
 
 ---
 
 ## Dependencies & Environment Setup
 
-All code should be run inside the **Conda** environment `fr_sent_ml` for reproducibility.
+```bash
+# 1. Clone
+git clone https://github.com/LeonHauch/LLM_in_portfoliomanagement.git
+cd LLM_in_portfoliomanagement
 
-1. **Clone the repo**:
+# 2. Create Conda environment
+conda env create --file environment.yml
+conda activate fr_sent_ml
 
-   ```bash
-   git clone git@github.com:<YourUser>/french-rl-sentiment-portfolio.git
-   cd french-rl-sentiment-portfolio
-   ```
-
-2. **Create and activate the Conda environment**:
-
-   ```bash
-   conda env create --file environment.yml
-   conda activate fr_sent_ml
-   ```
-
-3. **Install additional pip packages**:
-
-   ```bash
-   pip install stable-baselines3 openai yfinance
-   ```
-
-4. **Set API keys**: create a `.env` file in the project root:
-
-   ```ini
-   OPENAI_API_KEY=sk-...
-   HUGGINGFACE_TOKEN=hf-...
-   ```
-
-5. **Verify installation**:
-
-   ```bash
-   python -c "import pandas, gym, stable_baselines3, openai; print('✅ OK')"
-   ```
+# 3. Verify
+python -c "import pandas, gymnasium, stable_baselines3, torch; print('OK')"
+```
 
 ---
 
 ## Data Acquisition
 
-### 1. Price Data
+### Price Data
 
-* **Script**: `src/data/download_prices.py`
-* **Assets**: CAC 40 constituents (e.g., `AIR.PA`, `BNP.PA`, …)
-* **Period**: 2018-01-01 to 2024-12-31
-* **Output**: MultiIndex CSVs in `data/raw/`
-
-Run:
+* **Script:** `data/download_prices.py`
+* **Assets:** 27 CAC 40 constituents (e.g. `AIR.PA`, `BNP.PA`, `MC.PA`, ...)
+* **Period:** 2018-01-01 to 2024-12-31
+* **Source:** Yahoo Finance via `yfinance`
 
 ```bash
-python src/data/download_prices.py
+python data/download_prices.py
 ```
 
-Raw data saved as `<ticker>.csv`.
+### Data Preprocessing
 
-### 2. News Data (Future Extension)
-
-* Planned via RSS/API scraping of Les Échos, Reuters France, etc.
-* Stored in `data/raw/news/` as JSON/CSV.
+* **Notebook:** `notebooks/01_prepare_data.ipynb` and `notebooks/convert_data_returns.ipynb`
+* Features per asset: Adj Close, Volume Ratio, Log Return, RSI, MACD, Bollinger, Rolling Volatility
+* Output: `data/preprocessed/data_ppo.parquet` (1,744 rows x 216 columns)
 
 ---
 
-## Data Preprocessing
+## The Environment
 
-### Price Data → Returns
+`environment/portfolio_env.py` — a Gymnasium environment for daily portfolio allocation.
 
-* **Notebook**: `notebooks/01_prepare_data.ipynb`
-* **Steps**:
+**Observations:** Flat vector of `(lookback_window x n_assets x n_features) + portfolio_weights`. Default: 60-day lookback, 5 features per asset (log returns, volume ratio, rolling volatility, correlation, SMA ratio), plus optional sentiment.
 
-  1. Load `data/raw/*.csv` with `pd.read_csv(header=[0,1], index_col=0)`
-  2. Concatenate into one DataFrame `price_data`
-  3. Compute log-returns: `r_t = log(P_t/P_{t-1})`
-  4. Drop missing
-  5. Save to `data/preprocessed/prices.parquet`
+**Actions:** Continuous weights passed through softmax to sum to 1. Supports a cash allocation.
 
-```python
-price_data.to_parquet('data/preprocessed/prices.parquet')
-```
+**Reward:** Net log-return after transaction costs (0.1%), with an optional configurable risk-adjustment bonus (off by default).
 
-### Sentiment Data → Signals
-
-*(Optional for baseline)*
-
-* Extract daily sentiment scores using GPT-4 API
-* Stored in `data/processed/sentiment.parquet`
+**Train/test split:** Set via `start_date`/`end_date` or `start_idx`/`end_idx` parameters. Default split: train on 2018-2022, test on 2023-2024.
 
 ---
 
 ## Training the PPO Agent
 
-### 1. Environment
+```bash
+# Basic training (uses default config)
+python src/rl_agent/train_ppo.py \
+    --data-path data/preprocessed/data_ppo.parquet \
+    --config config_minimal.yaml
 
-* **File**: `src/rl_agent/portfolio_env.py`
-* **Observations**: price returns + portfolio weights
-* **Actions**: continuous allocations (∑w\_i=1)
-* **Reward**: portfolio return minus transaction cost (0.4%)
+# Multi-seed training
+python src/rl_agent/train_ppo.py \
+    --data-path data/preprocessed/data_ppo.parquet \
+    --config config_minimal.yaml \
+    --seeds 42,123,456
 
-### 2. Training Script
+# Training with sentiment
+python src/rl_agent/train_ppo.py \
+    --data-path data/preprocessed/data_ppo.parquet \
+    --sentiment-path data/preprocessed/sentiment.csv \
+    --config config_minimal.yaml
+```
 
-* **File**: `src/rl_agent/train_ppo.py`
-* **Command**:
+### Policy Selection
 
-  ```bash
-  python src/rl_agent/train_ppo.py --config src/config.yaml
-  ```
-* **Output**: Saved model in `models/ppo_base.zip` (and `ppo_sentiment.zip` if sentiment used)
+Set in the config YAML:
+
+```yaml
+policy:
+  type: cnn      # mlp | cnn | lstm
+  features_dim: 128
+```
+
+* **mlp:** Default fully-connected (baseline)
+* **cnn:** 1D convolution over the time axis — captures temporal patterns
+* **lstm:** Recurrent processing of the lookback window
+
+All three use the same PPO optimization; only the feature extractor changes.
 
 ---
 
 ## Evaluation
 
-* **File**: `src/rl_agent/eval_ppo.py`
-* **Metrics**: Annualized return, volatility, Sharpe, Max drawdown
-* **Statistical Test**: Welch’s t-test on Sharpe distributions across seeds
-
 ```bash
-python src/rl_agent/eval_ppo.py --model models/ppo_base.zip --output results/base_metrics.json
+python src/rl_agent/eval_ppo_debug.py \
+    --model-path models/<run>/best_model.zip \
+    --data-path data/preprocessed/data_ppo.parquet \
+    --n-episodes 10
 ```
+
+**Metrics:** Annualized return, volatility, Sharpe ratio, Sortino ratio, max drawdown, Calmar ratio.
+
+### Classical Baselines
+
+```python
+from src.rl_agent.baselines import run_all_baselines
+
+results = run_all_baselines(
+    data_path="data/preprocessed/data_ppo.parquet",
+    start_idx=1200,  # test period start
+    end_idx=1743,     # test period end
+)
+for name, metrics in results.items():
+    print(f"{name}: Sharpe={metrics['sharpe_ratio']:.3f}")
+```
+
+Baselines included: equal-weight (daily & monthly rebalance), buy-and-hold, inverse-volatility.
 
 ---
 
-## Extending with Sentiment
+## Sentiment Integration
 
-1. Run sentiment extraction:
+### 1. Score headlines
 
-   ```bash
-   python src/sentiment/extract_sentiment.py --input data/raw/news --output data/processed/sentiment.parquet
-   ```
-2. Retrain PPO with sentiment flag:
+```bash
+# From real news data
+python src/sentiment/extract_sentiment.py score \
+    --input data/raw/news/headlines.csv \
+    --output data/preprocessed/sentiment.csv \
+    --model camembert
 
-   ```bash
-   python src/rl_agent/train_ppo.py --config src/config_sent.yaml
-   ```
+# Or generate dummy sentiment for testing
+python src/sentiment/extract_sentiment.py dummy \
+    --data-path data/preprocessed/data_ppo.parquet \
+    --output data/preprocessed/sentiment_dummy.csv
+```
 
-Compare `ppo_base` vs `ppo_sentiment` metrics.
+**Models available:**
+* `camembert` — CamemBERT fine-tuned on French text (tblard/tf-allocine)
+* `finbert` — ProsusAI/finbert for English financial text
+
+### 2. Train with sentiment
+
+```yaml
+# In config:
+env:
+  use_sentiment: true
+sentiment_path: data/preprocessed/sentiment.csv
+```
+
+The trainer merges sentiment into `Sentiment_{ticker}` columns; the environment reads them automatically.
+
+---
+
+## Configuration
+
+Example config (see `config_minimal.yaml` for a quick-test version):
+
+```yaml
+seed: 42
+data_path: data/preprocessed/data_ppo.parquet
+
+split:
+  train_end_date: "2022-12-31"
+  test_start_date: "2023-01-01"
+
+policy:
+  type: cnn
+  features_dim: 128
+
+env:
+  lookback_window: 60
+  transaction_cost: 0.001
+  cash_weight: true
+  use_sentiment: false
+  risk_bonus_weight: 0.0
+
+training:
+  total_timesteps: 1000000
+  n_envs: 4
+  learning_rate: 0.0003
+```
 
 ---
 
 ## Reproducibility & CI
 
-* **GitHub Actions** in `.github/workflows/ci.yml` to lint, test, and validate environment.
-* **Seed control** in `src/utils/seed.py` ensures deterministic runs per seed.
-* Use **Docker** (optional) for environment encapsulation.
+* **GitHub Actions** in `.github/workflows/conda-tests.yml` — runs pytest on push/PR
+* **Multi-seed training** via `--seeds` flag for statistical robustness
+* **Conda environment** pinned in `environment.yml`
 
 ---
 
 ## Project Roadmap
 
-* [x] Baseline PPO on CAC 40 returns
-* [ ] Integrate French financial news sentiment
+* [x] Baseline PPO on CAC 40 returns
+* [x] Train/test temporal split & classical baselines
+* [x] CNN/LSTM policy architectures
+* [x] Sentiment extraction pipeline (CamemBERT)
+* [ ] Acquire French financial news corpus (Les Echos, Reuters France)
+* [ ] Full sentiment-enhanced training & ablation study
 * [ ] Cross-market comparison (US vs France)
-* [ ] Analysis of translation vs direct sentiment on French text
-
----
-
-## Contributing
-
-1. Fork the repo
-2. Create a feature branch
-3. Write tests and update docs
-4. Open a Pull Request
+* [ ] Analysis of translation vs direct French sentiment
 
 ---
 
 ## License
 
-This project is licensed under the MIT License — see `LICENSE` for details.
+MIT — see `LICENSE`.

--- a/environment/portfolio_env.py
+++ b/environment/portfolio_env.py
@@ -1,21 +1,26 @@
-# src/environment/portfolio_env.py
+# environment/portfolio_env.py
 import gymnasium as gym
 from gymnasium import spaces
 import numpy as np
 import pandas as pd
-from typing import Dict, Tuple, Any, Optional
+from typing import Dict, Tuple, Any, Optional, List
 import logging
 
 logger = logging.getLogger(__name__)
 
+
 class PortfolioEnv(gym.Env):
     """
     Portfolio management environment for PPO training.
-    
-    This environment simulates portfolio allocation decisions across multiple assets
-    based on historical price and volume data.
+
+    Simulates portfolio allocation decisions across multiple assets
+    based on historical price and volume data. Supports temporal
+    train/test splitting, optional sentiment features, and structured
+    observations for CNN/LSTM policies.
     """
-    
+
+    metadata = {"render_modes": ["human"]}
+
     def __init__(
         self,
         data_path: str,
@@ -25,23 +30,33 @@ class PortfolioEnv(gym.Env):
         max_positions: Optional[int] = None,
         cash_weight: bool = True,
         normalize_observations: bool = True,
-        reward_scaling: float = 1000.0
+        reward_scaling: float = 1000.0,
+        start_idx: Optional[int] = None,
+        end_idx: Optional[int] = None,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+        use_sentiment: bool = False,
+        risk_bonus_weight: float = 0.0,
     ):
         """
-        Initialize the portfolio environment.
-        
         Args:
-            data_path: Path to the parquet file with preprocessed data
-            lookback_window: Number of historical periods to include in observation
-            initial_capital: Starting portfolio value
-            transaction_cost: Transaction cost as percentage of trade value
-            max_positions: Maximum number of positions (None for no limit)
-            cash_weight: Whether to include cash as an asset option
-            normalize_observations: Whether to normalize observation features
-            reward_scaling: Scaling factor for rewards
+            data_path: Path to the parquet file with preprocessed data.
+            lookback_window: Number of historical periods in observation.
+            initial_capital: Starting portfolio value.
+            transaction_cost: Cost as fraction of traded value.
+            max_positions: Maximum simultaneous positions (None = no limit).
+            cash_weight: Whether to include cash as an allocable asset.
+            normalize_observations: Clip observations to [-10, 10].
+            reward_scaling: Multiplicative factor applied to reward.
+            start_idx: First usable row index (inclusive). Overridden by start_date.
+            end_idx: Last usable row index (inclusive). Overridden by end_date.
+            start_date: Earliest date string (inclusive, ISO format) for this split.
+            end_date: Latest date string (inclusive, ISO format) for this split.
+            use_sentiment: If True, include Sentiment_* columns in observations.
+            risk_bonus_weight: Weight for rolling-Sharpe reward bonus (0 = pure return).
         """
         super().__init__()
-        
+
         self.data_path = data_path
         self.lookback_window = lookback_window
         self.initial_capital = initial_capital
@@ -50,294 +65,335 @@ class PortfolioEnv(gym.Env):
         self.cash_weight = cash_weight
         self.normalize_observations = normalize_observations
         self.reward_scaling = reward_scaling
-        
+        self.use_sentiment = use_sentiment
+        self.risk_bonus_weight = risk_bonus_weight
+
+        # Train/test boundaries (resolved after data load)
+        self._start_idx_param = start_idx
+        self._end_idx_param = end_idx
+        self._start_date_param = start_date
+        self._end_date_param = end_date
+
         # Load and prepare data
         self._load_data()
+        self._resolve_date_range()
         self._setup_spaces()
-        
+
         # Initialize state
         self.reset()
-        
+
+    # ------------------------------------------------------------------
+    # Data loading
+    # ------------------------------------------------------------------
     def _load_data(self):
-        """Load and process the parquet data."""
+        """Load parquet and derive features."""
         logger.info(f"Loading data from {self.data_path}")
-        
-        # Load the parquet file
         self.raw_data = pd.read_parquet(self.data_path)
-        
-        # Extract asset names from column names
-        adj_close_cols = [col for col in self.raw_data.columns if col.startswith('Adj Close_')]
-        volume_ratio_cols = [col for col in self.raw_data.columns if col.startswith('Volume_Ratio_')]
-        
-        # Extract asset symbols
-        self.asset_symbols = [col.replace('Adj Close_', '') for col in adj_close_cols]
+
+        # Extract asset columns
+        adj_close_cols = sorted(
+            [c for c in self.raw_data.columns if c.startswith("Adj Close_")]
+        )
+        volume_ratio_cols = sorted(
+            [c for c in self.raw_data.columns if c.startswith("Volume_Ratio_")]
+        )
+
+        self.asset_symbols = [c.replace("Adj Close_", "") for c in adj_close_cols]
         self.n_assets = len(self.asset_symbols)
-        
         logger.info(f"Found {self.n_assets} assets: {self.asset_symbols[:5]}...")
-        
-        # Organize data by asset
+
+        # Price & volume dataframes with simple column names
         self.price_data = self.raw_data[adj_close_cols].copy()
-        self.volume_data = self.raw_data[volume_ratio_cols].copy()
-        
-        # Rename columns to just asset symbols
         self.price_data.columns = self.asset_symbols
-        self.volume_data.columns = self.asset_symbols
-        
-        # Calculate returns
-        self.returns_data = self.price_data.pct_change().fillna(0)
-        
-        # Calculate additional features
+
+        self.volume_data = pd.DataFrame(index=self.raw_data.index)
+        for sym in self.asset_symbols:
+            col = f"Volume_Ratio_{sym}"
+            if col in self.raw_data.columns:
+                self.volume_data[sym] = self.raw_data[col]
+            else:
+                self.volume_data[sym] = 0.0
+
+        # Log returns: r_t = ln(P_t / P_{t-1})
+        self.returns_data = np.log(self.price_data / self.price_data.shift(1)).fillna(0)
+
+        # Technical features
         self._calculate_features()
-        
-        # Set valid date range (excluding lookback period)
-        self.valid_start_idx = self.lookback_window
-        self.valid_end_idx = len(self.raw_data) - 1
-        
-        logger.info(f"Data loaded: {len(self.raw_data)} periods, valid range: {self.valid_start_idx} to {self.valid_end_idx}")
-        
+
+        # Sentiment features (optional)
+        self.has_sentiment = False
+        if self.use_sentiment:
+            sent_cols = sorted(
+                [c for c in self.raw_data.columns if c.startswith("Sentiment_")]
+            )
+            if sent_cols:
+                self.sentiment_data = self.raw_data[sent_cols].copy()
+                self.sentiment_data.columns = [
+                    c.replace("Sentiment_", "") for c in sent_cols
+                ]
+                # Align to asset list, fill missing with 0
+                self.sentiment_data = self.sentiment_data.reindex(
+                    columns=self.asset_symbols, fill_value=0.0
+                )
+                self.has_sentiment = True
+                logger.info(f"Sentiment features loaded for {len(sent_cols)} assets")
+            else:
+                logger.warning("use_sentiment=True but no Sentiment_* columns found")
+
+        logger.info(f"Data loaded: {len(self.raw_data)} periods")
+
     def _calculate_features(self):
-        """Calculate additional technical features."""
-        # Rolling volatility (20-period)
+        """Derive rolling volatility, correlation, and SMA ratio."""
         self.volatility_data = self.returns_data.rolling(window=20).std().fillna(0)
-        
-        # Rolling correlation with market (using first asset as proxy)
-        market_returns = self.returns_data.iloc[:, 0]
-        self.correlation_data = pd.DataFrame(index=self.returns_data.index, columns=self.asset_symbols)
-        
+
+        # Equal-weight market proxy
+        market_returns = self.returns_data.mean(axis=1)
+        self.correlation_data = pd.DataFrame(
+            index=self.returns_data.index, columns=self.asset_symbols, dtype=float
+        )
         for asset in self.asset_symbols:
-            self.correlation_data[asset] = self.returns_data[asset].rolling(window=20).corr(market_returns).fillna(0)
-        
-        # Simple moving averages ratio (price / SMA20)
+            self.correlation_data[asset] = (
+                self.returns_data[asset]
+                .rolling(window=20)
+                .corr(market_returns)
+                .fillna(0)
+            )
+
         sma_20 = self.price_data.rolling(window=20).mean()
         self.sma_ratio_data = (self.price_data / sma_20).fillna(1.0)
-        
+
+    # ------------------------------------------------------------------
+    # Train / test split resolution
+    # ------------------------------------------------------------------
+    def _resolve_date_range(self):
+        """Convert date/idx parameters into valid_start_idx and valid_end_idx."""
+        data_len = len(self.raw_data)
+
+        # Start from date if provided
+        if self._start_date_param is not None and hasattr(self.raw_data.index, "get_loc"):
+            try:
+                idx = self.raw_data.index.get_indexer(
+                    [pd.Timestamp(self._start_date_param)], method="bfill"
+                )[0]
+                self._start_idx_param = max(idx, self.lookback_window)
+            except Exception:
+                logger.warning(f"Could not resolve start_date={self._start_date_param}")
+        elif self._start_date_param is not None:
+            # Index might be integer-based; try matching a date column
+            logger.warning("start_date provided but index is not datetime; ignoring")
+
+        if self._end_date_param is not None and hasattr(self.raw_data.index, "get_loc"):
+            try:
+                idx = self.raw_data.index.get_indexer(
+                    [pd.Timestamp(self._end_date_param)], method="ffill"
+                )[0]
+                self._end_idx_param = min(idx, data_len - 1)
+            except Exception:
+                logger.warning(f"Could not resolve end_date={self._end_date_param}")
+
+        # Fall back to defaults
+        self.valid_start_idx = (
+            max(self._start_idx_param, self.lookback_window)
+            if self._start_idx_param is not None
+            else self.lookback_window
+        )
+        self.valid_end_idx = (
+            min(self._end_idx_param, data_len - 1)
+            if self._end_idx_param is not None
+            else data_len - 1
+        )
+
+        if self.valid_end_idx <= self.valid_start_idx:
+            raise ValueError(
+                f"Invalid data range: start={self.valid_start_idx}, "
+                f"end={self.valid_end_idx}"
+            )
+
+        logger.info(
+            f"Date range resolved: idx [{self.valid_start_idx}, {self.valid_end_idx}] "
+            f"({self.valid_end_idx - self.valid_start_idx} tradable periods)"
+        )
+
+    # ------------------------------------------------------------------
+    # Spaces
+    # ------------------------------------------------------------------
     def _setup_spaces(self):
-        """Setup observation and action spaces."""
-        # Observation space: [lookback_window, n_features_per_asset]
-        # Features per asset: [returns, volume_ratio, volatility, correlation, sma_ratio]
+        """Define observation and action spaces."""
+        # Base features per asset: returns, volume, volatility, correlation, sma_ratio
         self.n_features_per_asset = 5
-        
-        if self.normalize_observations:
-            obs_low = -np.inf
-            obs_high = np.inf
-        else:
-            obs_low = -10.0  # Reasonable bounds for financial data
-            obs_high = 10.0
-            
-        # Add current portfolio weights to observation
+        if self.has_sentiment:
+            self.n_features_per_asset += 1  # sentiment score
+
         portfolio_features = self.n_assets + (1 if self.cash_weight else 0)
-        total_obs_features = self.lookback_window * self.n_assets * self.n_features_per_asset + portfolio_features
-        
+        total_obs_dim = (
+            self.lookback_window * self.n_assets * self.n_features_per_asset
+            + portfolio_features
+        )
+
         self.observation_space = spaces.Box(
-            low=obs_low,
-            high=obs_high,
-            shape=(total_obs_features,),
-            dtype=np.float32
+            low=-np.inf, high=np.inf, shape=(total_obs_dim,), dtype=np.float32
         )
-        
-        # Action space: portfolio weights (sum to 1)
-        # If cash_weight=True, include cash as an option
+
         action_dim = self.n_assets + (1 if self.cash_weight else 0)
-        
-        # Use Box space with post-processing to ensure weights sum to 1
         self.action_space = spaces.Box(
-            low=0.0,
-            high=1.0,
-            shape=(action_dim,),
-            dtype=np.float32
+            low=0.0, high=1.0, shape=(action_dim,), dtype=np.float32
         )
-        
-        logger.info(f"Observation space: {self.observation_space.shape}")
-        logger.info(f"Action space: {self.action_space.shape}")
-        
+
+        logger.info(
+            f"Obs space: {self.observation_space.shape}, "
+            f"Action space: {self.action_space.shape}"
+        )
+
+    # ------------------------------------------------------------------
+    # Observation
+    # ------------------------------------------------------------------
     def _get_observation(self) -> np.ndarray:
-        """Get current observation."""
-        # Get lookback window of features
-        start_idx = self.current_step - self.lookback_window
-        end_idx = self.current_step
-        
-        # Collect features for all assets over lookback window
-        features = []
-        
-        for i in range(start_idx, end_idx):
+        """Build flat observation vector."""
+        start = self.current_step - self.lookback_window
+        end = self.current_step
+
+        features: List[float] = []
+        for i in range(start, end):
             for asset in self.asset_symbols:
-                asset_features = [
+                asset_feats = [
                     self.returns_data.iloc[i][asset],
                     self.volume_data.iloc[i][asset],
                     self.volatility_data.iloc[i][asset],
-                    self.correlation_data.iloc[i][asset],
-                    self.sma_ratio_data.iloc[i][asset]
+                    float(self.correlation_data.iloc[i][asset]),
+                    self.sma_ratio_data.iloc[i][asset],
                 ]
-                features.extend(asset_features)
-        
-        # Add current portfolio weights
+                if self.has_sentiment:
+                    asset_feats.append(self.sentiment_data.iloc[i][asset])
+                features.extend(asset_feats)
+
         features.extend(self.current_weights)
-        
         obs = np.array(features, dtype=np.float32)
-        assert obs.ndim == 1 and obs.shape[0] == self.observation_space.shape[0], \
-            f"Observation shape mismatch: {obs.shape} vs {self.observation_space.shape}"
-        return obs
 
-        
-        # Normalize if requested
         if self.normalize_observations:
-            obs = np.clip(obs, -10, 10)  # Clip extreme values
-            
-        return obs
-    
-    def _process_action(self, action: np.ndarray) -> np.ndarray:
-        """Process raw action to valid portfolio weights."""
+            obs = np.clip(obs, -10, 10)
 
-        action = np.asarray(action, dtype=np.float64)
-        # If action comes in shape (n_envs, action_dim) and n_envs == 1, squeeze it
-        if action.ndim > 1 and action.shape[0] == 1:
-            action = action[0]
-        # If for some reason action is 2D (n_envs>1), pick the first env (this env is not vectorized internally)
-        if action.ndim > 1:
-            # if you want to fully support vectorized step() you'd need to handle batching; for now handle single env
-            action = action.squeeze()
-        
-        # numeric-stable softmax
-        action = np.clip(action, -50, 50)             # avoid overflow in exp
-        max_a = np.max(action)
-        exp_action = np.exp(action - max_a)
-        weights = exp_action / np.sum(exp_action, axis=-1)
-        
+        return obs
+
+    # ------------------------------------------------------------------
+    # Action processing
+    # ------------------------------------------------------------------
+    def _process_action(self, action: np.ndarray) -> np.ndarray:
+        """Convert raw network output to portfolio weights via softmax."""
+        action = np.asarray(action, dtype=np.float64).squeeze()
+        if action.ndim == 0:
+            action = action.reshape(1)
+
+        # Numerically-stable softmax
+        action = np.clip(action, -50, 50)
+        exp_a = np.exp(action - np.max(action))
+        weights = exp_a / exp_a.sum()
+
         if self.max_positions is not None and self.max_positions < len(weights):
-                # Keep only top max_positions weights, set others to 0
-            top_indices = np.argsort(weights)[-self.max_positions:]
-            new_weights = np.zeros_like(weights)
-            new_weights[top_indices] = weights[top_indices]
-            new_weights = new_weights / np.sum(new_weights)  # Renormalize
-            weights = new_weights
-                
+            top = np.argsort(weights)[-self.max_positions :]
+            mask = np.zeros_like(weights)
+            mask[top] = weights[top]
+            weights = mask / mask.sum()
+
         return weights
-    
+
+    # ------------------------------------------------------------------
+    # Reward
+    # ------------------------------------------------------------------
     def _calculate_reward(self, new_weights: np.ndarray) -> float:
-        """Calculate reward for the current step."""
-        # Get current period returns
-        current_returns = self.returns_data.iloc[self.current_step][self.asset_symbols].values
-        
-        # Calculate portfolio return
+        """Net log-return minus transaction costs, with optional risk bonus."""
+        current_returns = self.returns_data.iloc[self.current_step][
+            self.asset_symbols
+        ].values.astype(np.float64)
+
         if self.cash_weight:
-            # Last weight is cash (0% return)
             asset_weights = new_weights[:-1]
-            portfolio_return = np.dot(asset_weights, current_returns)
         else:
-            portfolio_return = np.dot(new_weights, current_returns)
-        
-        # Calculate transaction costs
+            asset_weights = new_weights
+
+        portfolio_return = float(np.dot(asset_weights, current_returns))
+
         weight_changes = np.abs(new_weights - self.current_weights)
-        transaction_costs = np.sum(weight_changes) * self.transaction_cost
-        
-        # Net return after transaction costs
-        net_return = portfolio_return - transaction_costs
-        
-        # Update portfolio value
-        self.portfolio_value *= (1 + net_return)
-        
-        # Base reward is the net return
+        tc = float(np.sum(weight_changes)) * self.transaction_cost
+        net_return = portfolio_return - tc
+
+        self.portfolio_value *= 1 + net_return
+
         reward = net_return
-        
-        # Add risk-adjusted component (Sharpe-like)
-        if len(self.returns_history) > 20:
-            recent_returns = np.array(self.returns_history[-20:])
-            if np.std(recent_returns) > 0:
-                risk_adjusted_reward = np.mean(recent_returns) / np.std(recent_returns)
-                reward += 0.1 * risk_adjusted_reward  # Small risk adjustment bonus
-        
-        # Scale reward
+
+        # Optional risk-adjusted bonus (off by default: risk_bonus_weight=0)
+        if self.risk_bonus_weight > 0 and len(self.returns_history) > 20:
+            recent = np.array(self.returns_history[-20:])
+            std = np.std(recent)
+            if std > 0:
+                reward += self.risk_bonus_weight * (np.mean(recent) / std)
+
         reward *= self.reward_scaling
-        
-        # Track returns
         self.returns_history.append(net_return)
-        
         return reward
-    
-    def step(self, action: np.ndarray) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
-        """Execute one step in the environment."""
+
+    # ------------------------------------------------------------------
+    # Step / Reset
+    # ------------------------------------------------------------------
+    def step(
+        self, action: np.ndarray
+    ) -> Tuple[np.ndarray, float, bool, bool, Dict[str, Any]]:
         action = np.asarray(action)
         if action.ndim > 1 and action.shape[0] == 1:
             action = action[0]
         if action.ndim != 1:
-            raise ValueError(f"Unexpected action ndim {action.ndim}, action shape: {action.shape}")
+            raise ValueError(
+                f"Unexpected action ndim {action.ndim}, shape: {action.shape}"
+            )
 
-        # Process action to get valid portfolio weights  
         new_weights = self._process_action(action)
-        
-        # Calculate reward
         reward = self._calculate_reward(new_weights)
-        
-        # Update current weights
         self.current_weights = new_weights.copy()
-        
-        # Move to next time step
         self.current_step += 1
-        
-        # Check if episode is done
+
         terminated = self.current_step >= self.valid_end_idx
         truncated = False
-        
-        # Get new observation
+
         if not terminated:
             obs = self._get_observation()
         else:
             obs = np.zeros(self.observation_space.shape[0], dtype=np.float32)
-        
-        # Info dictionary
+
         info = {
-            'portfolio_value': self.portfolio_value,
-            'weights': self.current_weights.copy(),
-            'step': self.current_step,
-            'net_return': self.returns_history[-1] if self.returns_history else 0.0
+            "portfolio_value": self.portfolio_value,
+            "weights": self.current_weights.copy(),
+            "step": self.current_step,
+            "net_return": self.returns_history[-1] if self.returns_history else 0.0,
         }
-        
         return obs, reward, terminated, truncated, info
-    
-    def reset(self, seed: Optional[int] = None, options: Optional[Dict] = None) -> Tuple[np.ndarray, Dict[str, Any]]:
-        """Reset the environment."""
+
+    def reset(
+        self, seed: Optional[int] = None, options: Optional[Dict] = None
+    ) -> Tuple[np.ndarray, Dict[str, Any]]:
         if seed is not None:
             np.random.seed(seed)
-        
-        # Reset to random starting point in valid range
-        self.current_step = np.random.randint(self.valid_start_idx, 
-                                            max(self.valid_start_idx + 1, self.valid_end_idx - 100))
-        
-        # Initialize portfolio
-        self.portfolio_value = self.initial_capital
-        
-        # Initialize weights (equal weight or cash-heavy)
-        action_dim = self.n_assets + (1 if self.cash_weight else 0)
-        if self.cash_weight:
-        # Start with small equal weights plus remaining in cash, normalized to sum 1
-            self.current_weights = np.ones(action_dim) * 0.1
-            self.current_weights[-1] = 0.1  # temporary
-            self.current_weights /= np.sum(self.current_weights)  # normalize to sum 1
 
-        else:
-            self.current_weights = np.ones(self.n_assets) / self.n_assets
-        
-        # Reset tracking variables
-        self.returns_history = []
-        
-        # Get initial observation
+        # Random start within valid range, leaving room for at least 100 steps
+        hi = max(self.valid_start_idx + 1, self.valid_end_idx - 100)
+        self.current_step = np.random.randint(self.valid_start_idx, hi)
+
+        self.portfolio_value = self.initial_capital
+        action_dim = self.n_assets + (1 if self.cash_weight else 0)
+        self.current_weights = np.ones(action_dim) / action_dim
+        self.returns_history: List[float] = []
+
         obs = self._get_observation()
-        
         info = {
-            'portfolio_value': self.portfolio_value,
-            'weights': self.current_weights.copy(),
-            'step': self.current_step
+            "portfolio_value": self.portfolio_value,
+            "weights": self.current_weights.copy(),
+            "step": self.current_step,
         }
-        
         return obs, info
-    
-    def render(self, mode: str = 'human'):
-        """Render the environment (optional)."""
-        if mode == 'human':
+
+    def render(self, mode: str = "human"):
+        if mode == "human":
             print(f"Step: {self.current_step}")
             print(f"Portfolio Value: ${self.portfolio_value:,.2f}")
-            print(f"Current Weights: {self.current_weights}")
-            print(f"Returns History Length: {len(self.returns_history)}")
+            print(f"Weights: {self.current_weights}")
             if self.returns_history:
-                print(f"Last Return: {self.returns_history[-1]:.4f}")
+                print(f"Last Return: {self.returns_history[-1]:.6f}")
             print("-" * 50)

--- a/src/rl_agent/baselines.py
+++ b/src/rl_agent/baselines.py
@@ -1,0 +1,246 @@
+# src/rl_agent/baselines.py
+"""
+Classical portfolio baselines for benchmarking the PPO agent.
+
+All baselines operate on the same data and produce the same metrics
+so results are directly comparable.
+"""
+import numpy as np
+import pandas as pd
+from typing import Dict, Optional
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def _load_returns(data_path: str, start_idx: int, end_idx: int) -> pd.DataFrame:
+    """Load parquet and compute log-return slice for the evaluation period."""
+    raw = pd.read_parquet(data_path)
+    adj_cols = sorted([c for c in raw.columns if c.startswith("Adj Close_")])
+    prices = raw[adj_cols].copy()
+    prices.columns = [c.replace("Adj Close_", "") for c in adj_cols]
+    log_returns = np.log(prices / prices.shift(1)).fillna(0)
+    return log_returns.iloc[start_idx:end_idx + 1]
+
+
+def _portfolio_metrics(
+    daily_returns: np.ndarray,
+    initial_capital: float = 100_000.0,
+    trading_days: int = 252,
+) -> Dict:
+    """Compute standard portfolio performance metrics."""
+    cumulative = np.cumprod(1 + daily_returns)
+    portfolio_values = initial_capital * cumulative
+
+    total_return = float(cumulative[-1] - 1)
+    n_years = len(daily_returns) / trading_days
+    ann_return = float((1 + total_return) ** (1 / max(n_years, 1e-6)) - 1)
+    ann_vol = float(np.std(daily_returns) * np.sqrt(trading_days))
+    sharpe = ann_return / ann_vol if ann_vol > 0 else 0.0
+
+    # Max drawdown
+    running_max = np.maximum.accumulate(cumulative)
+    drawdowns = (cumulative - running_max) / running_max
+    max_dd = float(np.min(drawdowns))
+
+    # Sortino (downside deviation)
+    neg_returns = daily_returns[daily_returns < 0]
+    downside_std = float(np.std(neg_returns) * np.sqrt(trading_days)) if len(neg_returns) > 0 else 1e-6
+    sortino = ann_return / downside_std
+
+    # Calmar
+    calmar = ann_return / abs(max_dd) if max_dd != 0 else 0.0
+
+    return {
+        "total_return": total_return,
+        "annualized_return": ann_return,
+        "annualized_volatility": ann_vol,
+        "sharpe_ratio": sharpe,
+        "sortino_ratio": sortino,
+        "max_drawdown": max_dd,
+        "calmar_ratio": calmar,
+        "portfolio_values": portfolio_values.tolist(),
+        "n_periods": len(daily_returns),
+    }
+
+
+def equal_weight_baseline(
+    data_path: str,
+    start_idx: int,
+    end_idx: int,
+    transaction_cost: float = 0.001,
+    rebalance_freq: int = 1,
+    initial_capital: float = 100_000.0,
+) -> Dict:
+    """
+    1/N equal-weight portfolio, rebalanced every `rebalance_freq` days.
+
+    Args:
+        data_path: Path to preprocessed parquet file.
+        start_idx: First row index (inclusive).
+        end_idx: Last row index (inclusive).
+        transaction_cost: Fractional cost per unit of turnover.
+        rebalance_freq: Rebalance every N days (1 = daily).
+        initial_capital: Starting capital.
+    """
+    returns_df = _load_returns(data_path, start_idx, end_idx)
+    n_assets = returns_df.shape[1]
+    target_w = np.ones(n_assets) / n_assets
+
+    daily_returns = []
+    current_w = target_w.copy()
+
+    for day in range(len(returns_df)):
+        asset_returns = returns_df.iloc[day].values
+        port_ret = float(np.dot(current_w, asset_returns))
+
+        # Rebalance?
+        if rebalance_freq > 0 and day % rebalance_freq == 0 and day > 0:
+            turnover = float(np.sum(np.abs(current_w - target_w)))
+            tc = turnover * transaction_cost
+            port_ret -= tc
+            current_w = target_w.copy()
+        else:
+            # Weights drift with returns
+            new_w = current_w * np.exp(asset_returns)
+            current_w = new_w / new_w.sum()
+
+        daily_returns.append(port_ret)
+
+    metrics = _portfolio_metrics(np.array(daily_returns), initial_capital)
+    metrics["strategy"] = "equal_weight"
+    metrics["rebalance_freq"] = rebalance_freq
+    logger.info(
+        f"Equal-weight baseline: Sharpe={metrics['sharpe_ratio']:.3f}, "
+        f"Return={metrics['total_return']:.2%}"
+    )
+    return metrics
+
+
+def buy_and_hold_baseline(
+    data_path: str,
+    start_idx: int,
+    end_idx: int,
+    initial_capital: float = 100_000.0,
+) -> Dict:
+    """
+    Buy-and-hold equal-weight portfolio (no rebalancing).
+    Equivalent to buying equal amounts at day 0 and holding.
+    """
+    returns_df = _load_returns(data_path, start_idx, end_idx)
+    n_assets = returns_df.shape[1]
+    current_w = np.ones(n_assets) / n_assets
+
+    daily_returns = []
+    for day in range(len(returns_df)):
+        asset_returns = returns_df.iloc[day].values
+        port_ret = float(np.dot(current_w, asset_returns))
+        daily_returns.append(port_ret)
+        # Drift
+        new_w = current_w * np.exp(asset_returns)
+        current_w = new_w / new_w.sum()
+
+    metrics = _portfolio_metrics(np.array(daily_returns), initial_capital)
+    metrics["strategy"] = "buy_and_hold"
+    logger.info(
+        f"Buy-and-hold baseline: Sharpe={metrics['sharpe_ratio']:.3f}, "
+        f"Return={metrics['total_return']:.2%}"
+    )
+    return metrics
+
+
+def inverse_volatility_baseline(
+    data_path: str,
+    start_idx: int,
+    end_idx: int,
+    vol_lookback: int = 60,
+    rebalance_freq: int = 20,
+    transaction_cost: float = 0.001,
+    initial_capital: float = 100_000.0,
+) -> Dict:
+    """
+    Inverse-volatility weighting (simple risk-parity proxy).
+    Weights proportional to 1/sigma, rebalanced periodically.
+    """
+    raw = pd.read_parquet(data_path)
+    adj_cols = sorted([c for c in raw.columns if c.startswith("Adj Close_")])
+    prices = raw[adj_cols].copy()
+    prices.columns = [c.replace("Adj Close_", "") for c in adj_cols]
+    log_returns = np.log(prices / prices.shift(1)).fillna(0)
+
+    # Need lookback before start for vol estimation
+    safe_start = max(0, start_idx - vol_lookback)
+    full_returns = log_returns.iloc[safe_start:end_idx + 1]
+
+    eval_returns = log_returns.iloc[start_idx:end_idx + 1]
+    n_assets = eval_returns.shape[1]
+
+    # Initial weights: inverse vol from lookback period
+    init_vol = full_returns.iloc[:vol_lookback].std().values
+    init_vol = np.where(init_vol > 0, init_vol, 1e-6)
+    current_w = (1 / init_vol) / (1 / init_vol).sum()
+
+    daily_returns = []
+    for day in range(len(eval_returns)):
+        asset_rets = eval_returns.iloc[day].values
+        port_ret = float(np.dot(current_w, asset_rets))
+
+        if rebalance_freq > 0 and day % rebalance_freq == 0 and day > 0:
+            # Recompute weights
+            lookback_start = max(0, start_idx + day - vol_lookback - safe_start)
+            lookback_end = start_idx + day - safe_start
+            recent_vol = full_returns.iloc[lookback_start:lookback_end].std().values
+            recent_vol = np.where(recent_vol > 0, recent_vol, 1e-6)
+            target_w = (1 / recent_vol) / (1 / recent_vol).sum()
+
+            turnover = float(np.sum(np.abs(current_w - target_w)))
+            tc = turnover * transaction_cost
+            port_ret -= tc
+            current_w = target_w.copy()
+        else:
+            new_w = current_w * np.exp(asset_rets)
+            current_w = new_w / new_w.sum()
+
+        daily_returns.append(port_ret)
+
+    metrics = _portfolio_metrics(np.array(daily_returns), initial_capital)
+    metrics["strategy"] = "inverse_volatility"
+    metrics["rebalance_freq"] = rebalance_freq
+    logger.info(
+        f"Inverse-vol baseline: Sharpe={metrics['sharpe_ratio']:.3f}, "
+        f"Return={metrics['total_return']:.2%}"
+    )
+    return metrics
+
+
+def run_all_baselines(
+    data_path: str,
+    start_idx: int,
+    end_idx: int,
+    transaction_cost: float = 0.001,
+    initial_capital: float = 100_000.0,
+) -> Dict[str, Dict]:
+    """Run all baseline strategies and return a dict of results."""
+    results = {}
+    results["equal_weight_daily"] = equal_weight_baseline(
+        data_path, start_idx, end_idx,
+        transaction_cost=transaction_cost,
+        rebalance_freq=1,
+        initial_capital=initial_capital,
+    )
+    results["equal_weight_monthly"] = equal_weight_baseline(
+        data_path, start_idx, end_idx,
+        transaction_cost=transaction_cost,
+        rebalance_freq=20,
+        initial_capital=initial_capital,
+    )
+    results["buy_and_hold"] = buy_and_hold_baseline(
+        data_path, start_idx, end_idx,
+        initial_capital=initial_capital,
+    )
+    results["inverse_volatility"] = inverse_volatility_baseline(
+        data_path, start_idx, end_idx,
+        transaction_cost=transaction_cost,
+        initial_capital=initial_capital,
+    )
+    return results

--- a/src/rl_agent/custom_policies.py
+++ b/src/rl_agent/custom_policies.py
@@ -1,0 +1,196 @@
+# src/rl_agent/custom_policies.py
+"""
+Custom feature extractors for Stable-Baselines3 PPO.
+
+The default MlpPolicy flattens the observation and ignores its temporal
+structure. These extractors reshape the flat vector back into a
+(lookback × assets × features) tensor and apply architectures with
+appropriate inductive biases.
+"""
+import torch
+import torch.nn as nn
+import numpy as np
+from gymnasium import spaces
+from stable_baselines3.common.torch_layers import BaseFeaturesExtractor
+from typing import Dict
+
+
+class PortfolioCNNExtractor(BaseFeaturesExtractor):
+    """
+    1-D CNN over the time axis of a (lookback, n_assets, n_features) tensor.
+
+    Architecture:
+        Input: (batch, lookback, n_assets * n_features)   [treat assets*features as channels]
+        → Conv1d(time_axis) → ReLU → Conv1d → ReLU → AdaptiveAvgPool → Flatten
+        → Linear → ReLU
+        + portfolio weights branch concatenated
+        → Linear → output embedding
+
+    This gives the network an inductive bias for temporal patterns
+    while keeping the model small enough for PPO on CPU.
+    """
+
+    def __init__(
+        self,
+        observation_space: spaces.Box,
+        n_assets: int,
+        n_features_per_asset: int,
+        lookback_window: int,
+        features_dim: int = 128,
+    ):
+        # features_dim is the final output dimensionality
+        super().__init__(observation_space, features_dim)
+
+        self.n_assets = n_assets
+        self.n_features = n_features_per_asset
+        self.lookback = lookback_window
+
+        # Number of portfolio-weight features appended at the end
+        obs_total = observation_space.shape[0]
+        self.n_portfolio_features = obs_total - (lookback_window * n_assets * n_features_per_asset)
+
+        in_channels = n_assets * n_features_per_asset
+
+        self.cnn = nn.Sequential(
+            nn.Conv1d(in_channels, 64, kernel_size=5, padding=2),
+            nn.ReLU(),
+            nn.Conv1d(64, 64, kernel_size=3, padding=1),
+            nn.ReLU(),
+            nn.AdaptiveAvgPool1d(1),  # → (batch, 64, 1)
+            nn.Flatten(),             # → (batch, 64)
+        )
+
+        # Combine CNN embedding + portfolio weights
+        combined_dim = 64 + self.n_portfolio_features
+        self.fc = nn.Sequential(
+            nn.Linear(combined_dim, features_dim),
+            nn.ReLU(),
+        )
+
+    def forward(self, observations: torch.Tensor) -> torch.Tensor:
+        batch = observations.shape[0]
+
+        # Split: market data vs portfolio weights
+        market_flat = observations[:, : self.lookback * self.n_assets * self.n_features]
+        port_weights = observations[:, self.lookback * self.n_assets * self.n_features :]
+
+        # Reshape to (batch, lookback, n_assets * n_features)
+        market = market_flat.view(batch, self.lookback, self.n_assets * self.n_features)
+
+        # Conv1d expects (batch, channels, length) → transpose
+        market = market.permute(0, 2, 1)  # (batch, n_assets*n_features, lookback)
+
+        cnn_out = self.cnn(market)  # (batch, 64)
+        combined = torch.cat([cnn_out, port_weights], dim=1)
+        return self.fc(combined)
+
+
+class PortfolioLSTMExtractor(BaseFeaturesExtractor):
+    """
+    LSTM over the time axis, processing each timestep's (n_assets * n_features)
+    vector sequentially.
+
+    Architecture:
+        Input: (batch, lookback, n_assets * n_features)
+        → LSTM → take last hidden state
+        + portfolio weights branch
+        → Linear → output embedding
+    """
+
+    def __init__(
+        self,
+        observation_space: spaces.Box,
+        n_assets: int,
+        n_features_per_asset: int,
+        lookback_window: int,
+        features_dim: int = 128,
+        lstm_hidden: int = 64,
+    ):
+        super().__init__(observation_space, features_dim)
+
+        self.n_assets = n_assets
+        self.n_features = n_features_per_asset
+        self.lookback = lookback_window
+
+        obs_total = observation_space.shape[0]
+        self.n_portfolio_features = obs_total - (lookback_window * n_assets * n_features_per_asset)
+
+        input_size = n_assets * n_features_per_asset
+        self.lstm = nn.LSTM(
+            input_size=input_size,
+            hidden_size=lstm_hidden,
+            num_layers=1,
+            batch_first=True,
+        )
+
+        combined_dim = lstm_hidden + self.n_portfolio_features
+        self.fc = nn.Sequential(
+            nn.Linear(combined_dim, features_dim),
+            nn.ReLU(),
+        )
+
+    def forward(self, observations: torch.Tensor) -> torch.Tensor:
+        batch = observations.shape[0]
+
+        market_flat = observations[:, : self.lookback * self.n_assets * self.n_features]
+        port_weights = observations[:, self.lookback * self.n_assets * self.n_features :]
+
+        market = market_flat.view(batch, self.lookback, self.n_assets * self.n_features)
+
+        _, (h_n, _) = self.lstm(market)  # h_n: (1, batch, hidden)
+        lstm_out = h_n.squeeze(0)  # (batch, hidden)
+
+        combined = torch.cat([lstm_out, port_weights], dim=1)
+        return self.fc(combined)
+
+
+def get_policy_kwargs(
+    policy_type: str,
+    n_assets: int,
+    n_features_per_asset: int,
+    lookback_window: int,
+    observation_space: spaces.Box,
+    features_dim: int = 128,
+) -> Dict:
+    """
+    Build the policy_kwargs dict for SB3's PPO constructor.
+
+    Args:
+        policy_type: One of "mlp", "cnn", "lstm".
+        n_assets: Number of tradeable assets.
+        n_features_per_asset: Features per asset per timestep.
+        lookback_window: Temporal lookback.
+        observation_space: The env's observation space.
+        features_dim: Embedding dimension for actor/critic heads.
+
+    Returns:
+        Dict suitable for PPO(..., policy_kwargs=...).
+    """
+    if policy_type == "mlp":
+        return {"net_arch": [dict(pi=[256, 128], vf=[256, 128])]}
+
+    if policy_type == "cnn":
+        return {
+            "features_extractor_class": PortfolioCNNExtractor,
+            "features_extractor_kwargs": {
+                "n_assets": n_assets,
+                "n_features_per_asset": n_features_per_asset,
+                "lookback_window": lookback_window,
+                "features_dim": features_dim,
+            },
+            "net_arch": [dict(pi=[128], vf=[128])],
+        }
+
+    if policy_type == "lstm":
+        return {
+            "features_extractor_class": PortfolioLSTMExtractor,
+            "features_extractor_kwargs": {
+                "n_assets": n_assets,
+                "n_features_per_asset": n_features_per_asset,
+                "lookback_window": lookback_window,
+                "features_dim": features_dim,
+            },
+            "net_arch": [dict(pi=[128], vf=[128])],
+        }
+
+    raise ValueError(f"Unknown policy_type: {policy_type!r}. Use 'mlp', 'cnn', or 'lstm'.")

--- a/src/rl_agent/train_ppo.py
+++ b/src/rl_agent/train_ppo.py
@@ -1,16 +1,14 @@
-# src/training/train_ppo.py
+# src/rl_agent/train_ppo.py
 import os
+import sys
 import numpy as np
 import pandas as pd
-
 from pathlib import Path
 from stable_baselines3 import PPO
-from stable_baselines3.common.env_util import make_vec_env
 from stable_baselines3.common.callbacks import (
-    EvalCallback, 
-    CheckpointCallback, 
-    StopTrainingOnRewardThreshold,
-    CallbackList
+    EvalCallback,
+    CheckpointCallback,
+    CallbackList,
 )
 from stable_baselines3.common.monitor import Monitor
 from stable_baselines3.common.vec_env import DummyVecEnv, SubprocVecEnv
@@ -19,405 +17,410 @@ import torch
 import argparse
 import logging
 from datetime import datetime
-from pathlib import Path
 import yaml
 import json
 
-# Import your custom environment
-import sys
-sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
 from environment.portfolio_env import PortfolioEnv
+from src.rl_agent.custom_policies import get_policy_kwargs
 
-# Setup logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+
 class PortfolioTrainer:
-    """Main trainer class for PPO portfolio optimization."""
-    
-    def __init__(self, config_path: str = None, data_path: str = None, sentiment_path: str = None):
-        """
-        Initialize the trainer.
-        
-        Args:
-            config_path: Path to configuration file
-            data_path: Path to the parquet data file
-            sentiment_path: Optional path to sentiment CSV file
-        """
+    """PPO trainer with train/test split, policy selection, and multi-seed support."""
+
+    def __init__(
+        self,
+        config_path: str = None,
+        data_path: str = None,
+        sentiment_path: str = None,
+    ):
         self.config = self._load_config(config_path)
-        self.data_path = data_path or self.config.get('data_path')
-        self.sentiment_path = sentiment_path or self.config.get('sentiment_path')  # NEW
-        
-        # Prepare data (merge sentiment if provided)
-        self._prepare_data()  # NEW
-        
-        # Setup directories
+        self.data_path = data_path or self.config.get("data_path")
+        self.sentiment_path = sentiment_path or self.config.get("sentiment_path")
+
+        self._prepare_data()
         self.setup_directories()
-        
-        # Set random seeds for reproducibility
-        self.seed = self.config.get('seed', 42)
+
+        self.seed = self.config.get("seed", 42)
         set_random_seed(self.seed)
         torch.manual_seed(self.seed)
         np.random.seed(self.seed)
-        
         logger.info(f"Trainer initialized with seed: {self.seed}")
-    
-    def _prepare_data(self):
-        """
-        Load market data and optionally merge with sentiment.
-        If sentiment is provided, creates a temporary merged file.
-        """
-        
-        # Check if sentiment should be merged
-        if self.sentiment_path and os.path.exists(self.sentiment_path):
-            logger.info(f"📊 Loading sentiment from: {self.sentiment_path}")
-            
-            try:
-                # Load market data
-                market_data = pd.read_parquet(self.data_path)
-                logger.info(f"   Market data shape: {market_data.shape}")
-                
-                # Load sentiment
-                sentiment_data = pd.read_csv(self.sentiment_path)
-                sentiment_data['date'] = pd.to_datetime(sentiment_data['date'])
-                logger.info(f"   Sentiment data shape: {sentiment_data.shape}")
-                
-                # Ensure market data has datetime date column
-                if 'date' in market_data.columns:
-                    market_data['date'] = pd.to_datetime(market_data['date'])
-                
-                # Merge on date and asset
-                merged_data = market_data.merge(
-                    sentiment_data,
-                    on=['date', 'asset'],
-                    how='left'
-                )
-                
-                # Fill missing sentiment with 0 (neutral for days without news)
-                sentiment_cols = [c for c in sentiment_data.columns 
-                                if c not in ['date', 'asset']]
-                for col in sentiment_cols:
-                    merged_data[col] = merged_data[col].fillna(0)
-                    logger.info(f"   Filled {merged_data[col].isna().sum()} missing values in '{col}'")
-                
-                logger.info(f"✅ Merged data shape: {merged_data.shape}")
-                logger.info(f"   Added sentiment columns: {sentiment_cols}")
-                
-                # Create temporary merged file
-                temp_dir = Path(self.data_path).parent / 'temp'
-                temp_dir.mkdir(exist_ok=True)
-                
-                timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-                temp_path = temp_dir / f"merged_with_sentiment_{timestamp}.parquet"
-                merged_data.to_parquet(temp_path)
-                
-                # Update data_path to point to merged file
-                self.original_data_path = self.data_path  # Keep reference to original
-                self.data_path = str(temp_path)
-                
-                logger.info(f"💾 Temporary merged data saved to: {temp_path}")
-                
-            except Exception as e:
-                logger.error(f"❌ Failed to merge sentiment data: {e}")
-                logger.info("   Continuing with original data without sentiment")
-                import traceback
-                traceback.print_exc()
-        
-        elif self.sentiment_path:
-            logger.warning(f"⚠️  Sentiment path provided but file not found: {self.sentiment_path}")
-            logger.info("   Training without sentiment features")
-        else:
-            logger.info("📈 Training without sentiment features (none provided)")
-           
+
+    # ------------------------------------------------------------------
+    # Config
+    # ------------------------------------------------------------------
     def _load_config(self, config_path: str) -> dict:
-        """Load configuration from file or use defaults."""
         default_config = {
-            'seed': 42,
-            'data_path': 'data/processed/portfolio_data.parquet',
-            
-            # Environment parameters
-            'env': {
-                'lookback_window': 60,
-                'initial_capital': 100000.0,
-                'transaction_cost': 0.001,
-                'max_positions': None,
-                'cash_weight': True,
-                'normalize_observations': True,
-                'reward_scaling': 1000.0
+            "seed": 42,
+            "data_path": "data/preprocessed/data_ppo.parquet",
+            "sentiment_path": None,
+            "env": {
+                "lookback_window": 60,
+                "initial_capital": 100000.0,
+                "transaction_cost": 0.001,
+                "max_positions": None,
+                "cash_weight": True,
+                "normalize_observations": True,
+                "reward_scaling": 1000.0,
+                "use_sentiment": False,
+                "risk_bonus_weight": 0.0,
             },
-            
-            # Training parameters
-            'training': {
-                'total_timesteps': 1000000,
-                'learning_rate': 3e-4,
-                'n_steps': 2048,
-                'batch_size': 64,
-                'n_epochs': 10,
-                'gamma': 0.99,
-                'gae_lambda': 0.95,
-                'clip_range': 0.2,
-                'ent_coef': 0.01,
-                'vf_coef': 0.5,
-                'max_grad_norm': 0.5,
-                'target_kl': None,
-                'n_envs': 4,
-                'use_multiprocessing': False
+            # Train/test split
+            "split": {
+                "train_end_idx": None,
+                "test_start_idx": None,
+                "train_end_date": "2022-12-31",
+                "test_start_date": "2023-01-01",
             },
-            
-            # Evaluation parameters
-            'evaluation': {
-                'eval_freq': 10000,
-                'n_eval_episodes': 10,
-                'eval_deterministic': True
+            "policy": {
+                "type": "mlp",       # mlp | cnn | lstm
+                "features_dim": 128,
             },
-            
-            # Saving parameters
-            'saving': {
-                'save_freq': 50000,
-                'save_path': 'models/ppo_portfolio',
-                'keep_best_only': True
+            "training": {
+                "total_timesteps": 1000000,
+                "learning_rate": 3e-4,
+                "n_steps": 2048,
+                "batch_size": 64,
+                "n_epochs": 10,
+                "gamma": 0.99,
+                "gae_lambda": 0.95,
+                "clip_range": 0.2,
+                "ent_coef": 0.01,
+                "vf_coef": 0.5,
+                "max_grad_norm": 0.5,
+                "target_kl": None,
+                "n_envs": 4,
+                "use_multiprocessing": False,
             },
-            
-            # Logging
-            'logging': {
-                'tensorboard': True,
-                'wandb': False,
-                'log_interval': 100
-            }
+            "evaluation": {
+                "eval_freq": 10000,
+                "n_eval_episodes": 10,
+                "eval_deterministic": True,
+            },
+            "saving": {
+                "save_freq": 50000,
+                "save_path": "models/ppo_portfolio",
+                "keep_best_only": True,
+            },
+            "logging": {
+                "tensorboard": True,
+                "wandb": False,
+                "log_interval": 100,
+            },
         }
-        
+
         if config_path and os.path.exists(config_path):
-            with open(config_path, 'r') as f:
-                if config_path.endswith('.yaml') or config_path.endswith('.yml'):
-                    loaded_config = yaml.safe_load(f)
+            with open(config_path, "r") as f:
+                if config_path.endswith((".yaml", ".yml")):
+                    loaded = yaml.safe_load(f)
                 else:
-                    loaded_config = json.load(f)
-            
-            # Merge with defaults
-            self._deep_update(default_config, loaded_config)
+                    loaded = json.load(f)
+            self._deep_update(default_config, loaded)
             logger.info(f"Configuration loaded from {config_path}")
         else:
             logger.info("Using default configuration")
-            
+
         return default_config
-    
-    def _deep_update(self, base_dict: dict, update_dict: dict):
-        """Deep update dictionary."""
-        for key, value in update_dict.items():
-            if key in base_dict and isinstance(base_dict[key], dict) and isinstance(value, dict):
-                self._deep_update(base_dict[key], value)
+
+    @staticmethod
+    def _deep_update(base: dict, update: dict):
+        for k, v in update.items():
+            if k in base and isinstance(base[k], dict) and isinstance(v, dict):
+                PortfolioTrainer._deep_update(base[k], v)
             else:
-                base_dict[key] = value
-    
+                base[k] = v
+
+    # ------------------------------------------------------------------
+    # Data preparation (sentiment merge)
+    # ------------------------------------------------------------------
+    def _prepare_data(self):
+        if self.sentiment_path and os.path.exists(self.sentiment_path):
+            logger.info(f"Loading sentiment from: {self.sentiment_path}")
+            try:
+                market = pd.read_parquet(self.data_path)
+                sent = pd.read_csv(self.sentiment_path)
+                sent["date"] = pd.to_datetime(sent["date"])
+
+                # Pivot sentiment to wide format: Sentiment_{ticker}
+                if "asset" in sent.columns and "sentiment" in sent.columns:
+                    pivot = sent.pivot_table(
+                        index="date", columns="asset", values="sentiment", aggfunc="mean"
+                    )
+                    pivot.columns = [f"Sentiment_{c}" for c in pivot.columns]
+                    # Align with market index
+                    if hasattr(market.index, "date"):
+                        pivot.index = pd.to_datetime(pivot.index)
+                        market = market.join(pivot, how="left")
+                    else:
+                        market = market.merge(
+                            pivot, left_index=True, right_index=True, how="left"
+                        )
+                    # Fill missing sentiment with 0
+                    for c in pivot.columns:
+                        market[c] = market[c].fillna(0)
+
+                    temp_dir = Path(self.data_path).parent / "temp"
+                    temp_dir.mkdir(exist_ok=True)
+                    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+                    temp_path = temp_dir / f"merged_sentiment_{ts}.parquet"
+                    market.to_parquet(temp_path)
+                    self.data_path = str(temp_path)
+                    logger.info(f"Merged sentiment data saved to {temp_path}")
+                else:
+                    logger.warning("Sentiment CSV missing 'asset'/'sentiment' columns")
+            except Exception as e:
+                logger.error(f"Failed to merge sentiment: {e}")
+        elif self.sentiment_path:
+            logger.warning(f"Sentiment path not found: {self.sentiment_path}")
+        else:
+            logger.info("Training without sentiment features")
+
+    # ------------------------------------------------------------------
+    # Directories
+    # ------------------------------------------------------------------
     def setup_directories(self):
-        """Create necessary directories."""
         self.timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-        
-        # Create directories
         self.model_dir = Path(f"models/ppo_portfolio_{self.timestamp}")
         self.log_dir = Path(f"logs/ppo_portfolio_{self.timestamp}")
         self.results_dir = Path(f"results/ppo_portfolio_{self.timestamp}")
-        
-        for directory in [self.model_dir, self.log_dir, self.results_dir]:
-            directory.mkdir(parents=True, exist_ok=True)
-            
-        logger.info(f"Directories created: {self.model_dir}")
-        
-    def create_env(self, rank: int = 0):
-        """Create a single environment instance."""
+        for d in [self.model_dir, self.log_dir, self.results_dir]:
+            d.mkdir(parents=True, exist_ok=True)
+
+    # ------------------------------------------------------------------
+    # Environment creation (with split support)
+    # ------------------------------------------------------------------
+    def _env_kwargs(self, split: str = "train") -> dict:
+        """Build PortfolioEnv kwargs for a given split."""
+        env_cfg = dict(self.config["env"])
+        split_cfg = self.config.get("split", {})
+
+        if split == "train":
+            env_cfg["end_date"] = split_cfg.get("train_end_date")
+            env_cfg["end_idx"] = split_cfg.get("train_end_idx")
+        elif split == "test":
+            env_cfg["start_date"] = split_cfg.get("test_start_date")
+            env_cfg["start_idx"] = split_cfg.get("test_start_idx")
+
+        return env_cfg
+
+    def create_env(self, rank: int = 0, split: str = "train"):
+        env_kwargs = self._env_kwargs(split)
+
         def _init():
-            env = PortfolioEnv(
-                data_path=self.data_path,
-                **self.config['env']
-            )
-            env = Monitor(env, str(self.log_dir / f"monitor_{rank}.csv"))
+            env = PortfolioEnv(data_path=self.data_path, **env_kwargs)
+            env = Monitor(env, str(self.log_dir / f"monitor_{split}_{rank}.csv"))
             return env
+
         return _init
-    
-    def create_vec_env(self):
-        """Create vectorized environment."""
-        n_envs = self.config['training']['n_envs']
-        use_multiprocessing = self.config['training']['use_multiprocessing']
-        
-        if use_multiprocessing and n_envs > 1:
-            env = SubprocVecEnv([self.create_env(i) for i in range(n_envs)])
+
+    def create_vec_env(self, split: str = "train"):
+        n_envs = self.config["training"]["n_envs"]
+        use_mp = self.config["training"]["use_multiprocessing"]
+        fns = [self.create_env(i, split) for i in range(n_envs)]
+        if use_mp and n_envs > 1:
+            env = SubprocVecEnv(fns)
         else:
-            env = DummyVecEnv([self.create_env(i) for i in range(n_envs)])
-            
-        logger.info(f"Created vectorized environment with {n_envs} instances")
+            env = DummyVecEnv(fns)
+        logger.info(f"Created {split} vec-env with {n_envs} instances")
         return env
-    
+
+    # ------------------------------------------------------------------
+    # Model creation (with policy selection)
+    # ------------------------------------------------------------------
     def create_model(self, env):
-        """Create PPO model."""
-        training_config = self.config['training']
-        
-        # PPO parameters
+        tc = self.config["training"]
+        policy_cfg = self.config.get("policy", {})
+        policy_type = policy_cfg.get("type", "mlp")
+
+        # Get env metadata for structured policies
+        sample_env = env.envs[0] if hasattr(env, "envs") else env
+        # Unwrap Monitor if needed
+        inner = sample_env
+        while hasattr(inner, "env"):
+            inner = inner.env
+        n_assets = inner.n_assets
+        n_features = inner.n_features_per_asset
+        lookback = inner.lookback_window
+
+        policy_kwargs = get_policy_kwargs(
+            policy_type=policy_type,
+            n_assets=n_assets,
+            n_features_per_asset=n_features,
+            lookback_window=lookback,
+            observation_space=env.observation_space,
+            features_dim=policy_cfg.get("features_dim", 128),
+        )
+
         model_params = {
-            'learning_rate': training_config['learning_rate'],
-            'n_steps': training_config['n_steps'],
-            'batch_size': training_config['batch_size'],
-            'n_epochs': training_config['n_epochs'],
-            'gamma': training_config['gamma'],
-            'gae_lambda': training_config['gae_lambda'],
-            'clip_range': training_config['clip_range'],
-            'ent_coef': training_config['ent_coef'],
-            'vf_coef': training_config['vf_coef'],
-            'max_grad_norm': training_config['max_grad_norm'],
-            'target_kl': training_config.get('target_kl'),
-            'tensorboard_log': str(self.log_dir) if self.config['logging']['tensorboard'] else None,
-            'seed': self.seed,
-            'verbose': 1
+            "learning_rate": tc["learning_rate"],
+            "n_steps": tc["n_steps"],
+            "batch_size": tc["batch_size"],
+            "n_epochs": tc["n_epochs"],
+            "gamma": tc["gamma"],
+            "gae_lambda": tc["gae_lambda"],
+            "clip_range": tc["clip_range"],
+            "ent_coef": tc["ent_coef"],
+            "vf_coef": tc["vf_coef"],
+            "max_grad_norm": tc["max_grad_norm"],
+            "target_kl": tc.get("target_kl"),
+            "tensorboard_log": str(self.log_dir)
+            if self.config["logging"]["tensorboard"]
+            else None,
+            "seed": self.seed,
+            "verbose": 1,
+            "policy_kwargs": policy_kwargs,
         }
-        
-        # Create model
+
         model = PPO("MlpPolicy", env, **model_params)
-        
-        logger.info("PPO model created with parameters:")
-        for key, value in model_params.items():
-            logger.info(f"  {key}: {value}")
-            
+        logger.info(f"PPO model created (policy={policy_type})")
         return model
-    
+
+    # ------------------------------------------------------------------
+    # Callbacks
+    # ------------------------------------------------------------------
     def create_callbacks(self, env):
-        """Create training callbacks."""
         callbacks = []
-        
-        # Evaluation callback
-        eval_config = self.config['evaluation']
-        if eval_config['eval_freq'] > 0:
-            eval_env = DummyVecEnv([self.create_env()])
-            eval_callback = EvalCallback(
-                eval_env,
-                best_model_save_path=str(self.model_dir),
-                log_path=str(self.log_dir),
-                eval_freq=eval_config['eval_freq'],
-                n_eval_episodes=eval_config['n_eval_episodes'],
-                deterministic=eval_config['eval_deterministic'],
-                render=False
+        ec = self.config["evaluation"]
+        if ec["eval_freq"] > 0:
+            eval_env = DummyVecEnv([self.create_env(split="train")])
+            callbacks.append(
+                EvalCallback(
+                    eval_env,
+                    best_model_save_path=str(self.model_dir),
+                    log_path=str(self.log_dir),
+                    eval_freq=ec["eval_freq"],
+                    n_eval_episodes=ec["n_eval_episodes"],
+                    deterministic=ec["eval_deterministic"],
+                    render=False,
+                )
             )
-            callbacks.append(eval_callback)
-            logger.info(f"Evaluation callback added (freq: {eval_config['eval_freq']})")
-        
-        # Checkpoint callback
-        save_config = self.config['saving']
-        if save_config['save_freq'] > 0:
-            checkpoint_callback = CheckpointCallback(
-                save_freq=save_config['save_freq'],
-                save_path=str(self.model_dir),
-                name_prefix='ppo_portfolio'
+        sc = self.config["saving"]
+        if sc["save_freq"] > 0:
+            callbacks.append(
+                CheckpointCallback(
+                    save_freq=sc["save_freq"],
+                    save_path=str(self.model_dir),
+                    name_prefix="ppo_portfolio",
+                )
             )
-            callbacks.append(checkpoint_callback)
-            logger.info(f"Checkpoint callback added (freq: {save_config['save_freq']})")
-        
         return CallbackList(callbacks) if callbacks else None
-    
-    def save_config(self):
-        """Save configuration to results directory."""
-        config_path = self.results_dir / 'config.yaml'
-        with open(config_path, 'w') as f:
-            yaml.dump(self.config, f, default_flow_style=False)
-        
-        logger.info(f"Configuration saved to {config_path}")
-    
+
+    # ------------------------------------------------------------------
+    # Training
+    # ------------------------------------------------------------------
     def train(self):
-        """Main training loop."""
         logger.info("Starting PPO training...")
-        
-        # Save configuration
         self.save_config()
-        
-        # Create environment
-        env = self.create_vec_env()
-        
-        # Create model
+        env = self.create_vec_env("train")
         model = self.create_model(env)
-        
-        # Create callbacks
         callbacks = self.create_callbacks(env)
-        
-        # Start training
-        total_timesteps = self.config['training']['total_timesteps']
-        
+        total = self.config["training"]["total_timesteps"]
+
         try:
             model.learn(
-                total_timesteps=total_timesteps,
+                total_timesteps=total,
                 callback=callbacks,
-                log_interval=self.config['logging']['log_interval'],
-                progress_bar=True
+                log_interval=self.config["logging"]["log_interval"],
+                progress_bar=True,
             )
-            
-            # Save final model
-            final_model_path = self.model_dir / 'final_model'
-            model.save(final_model_path)
-            
-            logger.info(f"Training completed! Final model saved to {final_model_path}")
-            
-            # Save training statistics
+            path = self.model_dir / "final_model"
+            model.save(path)
+            logger.info(f"Training completed! Model saved to {path}")
             self.save_training_stats(model)
-            
         except KeyboardInterrupt:
-            logger.info("Training interrupted by user")
-            # Save current model
-            interrupted_model_path = self.model_dir / 'interrupted_model'
-            model.save(interrupted_model_path)
-            logger.info(f"Model saved to {interrupted_model_path}")
-        
+            path = self.model_dir / "interrupted_model"
+            model.save(path)
+            logger.info(f"Training interrupted. Model saved to {path}")
         finally:
             env.close()
-            logger.info("Environment closed")
-            
-        return model
-    
-    def save_training_stats(self, model):
-        """Save training statistics."""
-        stats = {
-            'total_timesteps': model.num_timesteps,
-            'training_completed': True,
-            'model_path': str(self.model_dir),
-            'config': self.config,
-            'timestamp': self.timestamp
-        }
-        
-        stats_path = self.results_dir / 'training_stats.json'
-        with open(stats_path, 'w') as f:
-            json.dump(stats, f, indent=2, default=str)
-            
-        logger.info(f"Training statistics saved to {stats_path}")
 
+        return model
+
+    def save_config(self):
+        p = self.results_dir / "config.yaml"
+        with open(p, "w") as f:
+            yaml.dump(self.config, f, default_flow_style=False)
+
+    def save_training_stats(self, model):
+        stats = {
+            "total_timesteps": model.num_timesteps,
+            "training_completed": True,
+            "model_path": str(self.model_dir),
+            "config": self.config,
+            "timestamp": self.timestamp,
+        }
+        p = self.results_dir / "training_stats.json"
+        with open(p, "w") as f:
+            json.dump(stats, f, indent=2, default=str)
+
+
+# ======================================================================
+# Multi-seed training
+# ======================================================================
+def train_multi_seed(
+    config_path: str,
+    data_path: str,
+    seeds: list,
+    sentiment_path: str = None,
+) -> list:
+    """Train PPO across multiple seeds and return list of model paths."""
+    model_paths = []
+    for seed in seeds:
+        logger.info(f"\n{'='*60}\nTraining with seed={seed}\n{'='*60}")
+        trainer = PortfolioTrainer(
+            config_path=config_path,
+            data_path=data_path,
+            sentiment_path=sentiment_path,
+        )
+        trainer.config["seed"] = seed
+        trainer.seed = seed
+        set_random_seed(seed)
+        torch.manual_seed(seed)
+        np.random.seed(seed)
+
+        trainer.train()
+        model_paths.append(str(trainer.model_dir / "final_model.zip"))
+    return model_paths
+
+
+# ======================================================================
+# CLI
+# ======================================================================
 def main():
-    """Main function for command line usage."""
-    parser = argparse.ArgumentParser(description='Train PPO for Portfolio Optimization')
-    parser.add_argument('--data-path', type=str, required=False,
-                       help='Path to the parquet data file')
-    parser.add_argument('--config', type=str, default=None,
-                       help='Path to configuration file (YAML or JSON)')
-    parser.add_argument('--seed', type=int, default=42,
-                       help='Random seed for reproducibility')
-    parser.add_argument('--sentiment-path', type=str, default=None,
-                       help='Optional: Path to sentiment CSV file (date, asset, sentiment)')
-    
-    args = parser.parse_args()
-    
-    
-    trainer = PortfolioTrainer(
-        config_path=args.config, 
-        data_path=args.data_path,
-        sentiment_path=args.sentiment_path
+    parser = argparse.ArgumentParser(description="Train PPO for Portfolio Optimization")
+    parser.add_argument("--data-path", type=str, help="Path to parquet data file")
+    parser.add_argument("--config", type=str, default=None, help="Config YAML/JSON")
+    parser.add_argument("--seed", type=int, default=42, help="Random seed")
+    parser.add_argument(
+        "--seeds",
+        type=str,
+        default=None,
+        help="Comma-separated seeds for multi-seed training (e.g. 42,123,456)",
     )
-    
-    # Override seed if provided
-    if args.seed != 42:
-        trainer.config['seed'] = args.seed
-        trainer.seed = args.seed
-    
-    # NOW verify data file exists (after trainer has determined the final data_path)
-    if not os.path.exists(trainer.data_path):
-        raise FileNotFoundError(f"Data file not found: {trainer.data_path}")
-    
-    # Start training
-    model = trainer.train()
-    
-    logger.info("Training script completed!")
+    parser.add_argument("--sentiment-path", type=str, default=None)
+    args = parser.parse_args()
+
+    if args.seeds:
+        seeds = [int(s) for s in args.seeds.split(",")]
+        paths = train_multi_seed(args.config, args.data_path, seeds, args.sentiment_path)
+        logger.info(f"Multi-seed training done. Models: {paths}")
+    else:
+        trainer = PortfolioTrainer(
+            config_path=args.config,
+            data_path=args.data_path,
+            sentiment_path=args.sentiment_path,
+        )
+        if args.seed != 42:
+            trainer.config["seed"] = args.seed
+            trainer.seed = args.seed
+        if not os.path.exists(trainer.data_path):
+            raise FileNotFoundError(f"Data file not found: {trainer.data_path}")
+        trainer.train()
+
 
 if __name__ == "__main__":
     main()

--- a/src/sentiment/extract_sentiment.py
+++ b/src/sentiment/extract_sentiment.py
@@ -1,0 +1,248 @@
+# src/sentiment/extract_sentiment.py
+"""
+Sentiment extraction from French financial text using transformer models.
+
+Supports two approaches:
+  1. Direct French analysis via CamemBERT-based sentiment model
+  2. Translate-then-analyse via English FinBERT (for comparison)
+
+Usage:
+    python src/sentiment/extract_sentiment.py \
+        --input data/raw/news/headlines.csv \
+        --output data/preprocessed/sentiment.csv \
+        --model camembert
+
+The output CSV has columns: date, asset, sentiment
+where sentiment is in [-1, 1] (negative to positive).
+"""
+import argparse
+import logging
+import os
+from pathlib import Path
+from typing import List, Dict, Optional
+
+import numpy as np
+import pandas as pd
+import torch
+from transformers import (
+    AutoTokenizer,
+    AutoModelForSequenceClassification,
+    pipeline,
+)
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Model registry
+# ---------------------------------------------------------------------------
+MODELS = {
+    # CamemBERT fine-tuned for French sentiment (3-class: neg/neu/pos)
+    "camembert": "tblard/tf-allocine",
+    # Multilingual FinBERT-style model
+    "finbert": "ProsusAI/finbert",
+}
+
+
+def load_sentiment_pipeline(
+    model_name: str = "camembert", device: Optional[str] = None
+) -> pipeline:
+    """
+    Load a HuggingFace sentiment pipeline.
+
+    Args:
+        model_name: Key from MODELS dict or a HuggingFace model ID.
+        device: 'cpu', 'cuda', or None for auto-detect.
+
+    Returns:
+        transformers.pipeline for text-classification.
+    """
+    model_id = MODELS.get(model_name, model_name)
+
+    if device is None:
+        device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    logger.info(f"Loading sentiment model: {model_id} on {device}")
+
+    # Use device_map for proper placement
+    device_idx = 0 if device == "cuda" else -1
+
+    pipe = pipeline(
+        "text-classification",
+        model=model_id,
+        tokenizer=model_id,
+        device=device_idx,
+        truncation=True,
+        max_length=512,
+    )
+    logger.info("Sentiment pipeline ready")
+    return pipe
+
+
+def score_to_numeric(label: str, score: float, model_name: str = "camembert") -> float:
+    """
+    Convert a model's label + confidence to a single [-1, 1] score.
+
+    Different models have different label sets:
+      - CamemBERT (allocine): POSITIVE / NEGATIVE
+      - FinBERT: positive / negative / neutral
+    """
+    label_lower = label.lower()
+
+    if "pos" in label_lower:
+        return score
+    elif "neg" in label_lower:
+        return -score
+    else:
+        # neutral → near zero, slightly scaled by confidence
+        return 0.0
+
+
+def extract_sentiment_batch(
+    texts: List[str],
+    pipe,
+    model_name: str = "camembert",
+    batch_size: int = 32,
+) -> List[float]:
+    """
+    Score a list of texts and return numeric sentiments in [-1, 1].
+    """
+    results = pipe(texts, batch_size=batch_size)
+    scores = []
+    for r in results:
+        s = score_to_numeric(r["label"], r["score"], model_name)
+        scores.append(round(s, 4))
+    return scores
+
+
+def process_headlines_csv(
+    input_path: str,
+    output_path: str,
+    model_name: str = "camembert",
+    text_col: str = "headline",
+    date_col: str = "date",
+    asset_col: str = "asset",
+    batch_size: int = 32,
+) -> pd.DataFrame:
+    """
+    Read a CSV of headlines, score each, aggregate to daily per-asset sentiment.
+
+    Expected input columns: date, asset, headline
+    Output columns: date, asset, sentiment
+
+    Multiple headlines per (date, asset) are averaged.
+    """
+    logger.info(f"Reading headlines from {input_path}")
+    df = pd.read_csv(input_path)
+
+    required = {date_col, asset_col, text_col}
+    missing = required - set(df.columns)
+    if missing:
+        raise ValueError(f"Input CSV missing columns: {missing}")
+
+    df[date_col] = pd.to_datetime(df[date_col])
+    df = df.dropna(subset=[text_col])
+
+    texts = df[text_col].tolist()
+    logger.info(f"Scoring {len(texts)} headlines with model={model_name}")
+
+    pipe = load_sentiment_pipeline(model_name)
+    df["sentiment"] = extract_sentiment_batch(texts, pipe, model_name, batch_size)
+
+    # Aggregate: mean sentiment per (date, asset)
+    daily = (
+        df.groupby([date_col, asset_col])["sentiment"]
+        .mean()
+        .reset_index()
+    )
+    daily.columns = ["date", "asset", "sentiment"]
+
+    # Save
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    daily.to_csv(output_path, index=False)
+    logger.info(f"Sentiment saved to {output_path}: {len(daily)} rows")
+
+    return daily
+
+
+def generate_dummy_sentiment(
+    data_path: str,
+    output_path: str,
+    seed: int = 42,
+) -> pd.DataFrame:
+    """
+    Generate dummy sentiment data matching the market data's dates and assets.
+    Useful for testing the pipeline without real news data.
+
+    Produces a CSV with columns: date, asset, sentiment
+    where sentiment ~ N(0, 0.3) clipped to [-1, 1].
+    """
+    rng = np.random.RandomState(seed)
+    raw = pd.read_parquet(data_path)
+    adj_cols = sorted([c for c in raw.columns if c.startswith("Adj Close_")])
+    assets = [c.replace("Adj Close_", "") for c in adj_cols]
+    dates = raw.index if hasattr(raw.index, "date") else range(len(raw))
+
+    rows = []
+    for date in dates:
+        for asset in assets:
+            rows.append(
+                {"date": date, "asset": asset, "sentiment": rng.normal(0, 0.3)}
+            )
+
+    df = pd.DataFrame(rows)
+    df["sentiment"] = df["sentiment"].clip(-1, 1).round(4)
+
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(output_path, index=False)
+    logger.info(f"Dummy sentiment saved to {output_path}: {len(df)} rows")
+    return df
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+def main():
+    parser = argparse.ArgumentParser(description="Extract sentiment from French financial text")
+    sub = parser.add_subparsers(dest="command")
+
+    # --- score ---
+    score_p = sub.add_parser("score", help="Score headlines CSV")
+    score_p.add_argument("--input", required=True, help="Input headlines CSV")
+    score_p.add_argument("--output", required=True, help="Output sentiment CSV")
+    score_p.add_argument("--model", default="camembert", choices=list(MODELS.keys()))
+    score_p.add_argument("--batch-size", type=int, default=32)
+    score_p.add_argument("--text-col", default="headline")
+    score_p.add_argument("--date-col", default="date")
+    score_p.add_argument("--asset-col", default="asset")
+
+    # --- dummy ---
+    dummy_p = sub.add_parser("dummy", help="Generate dummy sentiment data")
+    dummy_p.add_argument("--data-path", required=True, help="Market data parquet")
+    dummy_p.add_argument("--output", required=True, help="Output sentiment CSV")
+    dummy_p.add_argument("--seed", type=int, default=42)
+
+    args = parser.parse_args()
+
+    if args.command == "score":
+        process_headlines_csv(
+            input_path=args.input,
+            output_path=args.output,
+            model_name=args.model,
+            text_col=args.text_col,
+            date_col=args.date_col,
+            asset_col=args.asset_col,
+            batch_size=args.batch_size,
+        )
+    elif args.command == "dummy":
+        generate_dummy_sentiment(
+            data_path=args.data_path,
+            output_path=args.output,
+            seed=args.seed,
+        )
+    else:
+        parser.print_help()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_portfolio_env.py
+++ b/tests/test_portfolio_env.py
@@ -2,29 +2,51 @@ import pytest
 import numpy as np
 import pandas as pd
 from environment.portfolio_env import PortfolioEnv
-import os
+
 
 @pytest.fixture
 def dummy_data(tmp_path):
     """Creates dummy data to simulate preprocessed input."""
-    dates = pd.date_range("2020-01-01", periods=100)
+    dates = pd.date_range("2020-01-01", periods=200)
+    rng = np.random.RandomState(42)
     data = {
-        "Adj Close_AAPL": np.linspace(100, 150, 100),
-        "Adj Close_GOOG": np.linspace(200, 250, 100),
-        "Volume_Ratio_AAPL": np.random.rand(100),
-        "Volume_Ratio_GOOG": np.random.rand(100)
+        "Adj Close_AAPL": np.linspace(100, 150, 200),
+        "Adj Close_GOOG": np.linspace(200, 250, 200),
+        "Volume_Ratio_AAPL": rng.rand(200),
+        "Volume_Ratio_GOOG": rng.rand(200),
     }
     df = pd.DataFrame(data, index=dates)
     file_path = tmp_path / "dummy.parquet"
     df.to_parquet(file_path)
     return str(file_path)
 
+
+@pytest.fixture
+def dummy_data_with_sentiment(tmp_path):
+    """Dummy data including sentiment columns."""
+    dates = pd.date_range("2020-01-01", periods=200)
+    rng = np.random.RandomState(42)
+    data = {
+        "Adj Close_AAPL": np.linspace(100, 150, 200),
+        "Adj Close_GOOG": np.linspace(200, 250, 200),
+        "Volume_Ratio_AAPL": rng.rand(200),
+        "Volume_Ratio_GOOG": rng.rand(200),
+        "Sentiment_AAPL": rng.uniform(-1, 1, 200),
+        "Sentiment_GOOG": rng.uniform(-1, 1, 200),
+    }
+    df = pd.DataFrame(data, index=dates)
+    file_path = tmp_path / "dummy_sent.parquet"
+    df.to_parquet(file_path)
+    return str(file_path)
+
+
 def test_env_initialization(dummy_data):
     env = PortfolioEnv(data_path=dummy_data, lookback_window=10)
     assert env.n_assets == 2
-    assert env.price_data.shape[0] == 100
+    assert env.price_data.shape[0] == 200
     assert env.price_data.shape[1] == 2
     assert env.action_space.shape == (3,)  # 2 assets + cash
+
 
 def test_env_reset(dummy_data):
     env = PortfolioEnv(data_path=dummy_data, lookback_window=10)
@@ -32,6 +54,7 @@ def test_env_reset(dummy_data):
     assert isinstance(obs, np.ndarray)
     assert obs.shape[0] == env.observation_space.shape[0]
     assert np.isclose(np.sum(env.current_weights), 1.0, atol=1e-3)
+
 
 def test_step_returns_valid_output(dummy_data):
     env = PortfolioEnv(data_path=dummy_data, lookback_window=10)
@@ -44,12 +67,84 @@ def test_step_returns_valid_output(dummy_data):
     assert isinstance(terminated, bool)
     assert isinstance(info, dict)
 
+
 def test_action_processing(dummy_data):
     env = PortfolioEnv(data_path=dummy_data, lookback_window=10, max_positions=1)
     obs, info = env.reset()
-    raw_action = np.array([10.0, 1.0, 0.0])  # Will be softmaxed
+    raw_action = np.array([10.0, 1.0, 0.0])
     weights = env._process_action(raw_action)
     assert np.isclose(np.sum(weights), 1.0)
     assert (weights >= 0).all()
     assert (weights <= 1).all()
-    assert np.count_nonzero(weights > 0) <= 1  # max_positions=1
+    assert np.count_nonzero(weights > 0) <= 1
+
+
+def test_log_returns(dummy_data):
+    """Returns should be log-returns, not arithmetic."""
+    env = PortfolioEnv(data_path=dummy_data, lookback_window=10)
+    prices = env.price_data.iloc[:3]
+    expected = np.log(prices.iloc[1] / prices.iloc[0])
+    actual = env.returns_data.iloc[1]
+    np.testing.assert_allclose(actual.values, expected.values, atol=1e-6)
+
+
+def test_train_test_split_by_idx(dummy_data):
+    """Env should respect start_idx / end_idx boundaries."""
+    env = PortfolioEnv(
+        data_path=dummy_data, lookback_window=10, start_idx=50, end_idx=150
+    )
+    assert env.valid_start_idx >= 50
+    assert env.valid_end_idx <= 150
+
+    for _ in range(20):
+        env.reset()
+        assert env.current_step >= env.valid_start_idx
+        assert env.current_step < env.valid_end_idx
+
+
+def test_train_test_split_by_date(dummy_data):
+    """Env should respect start_date / end_date boundaries."""
+    env = PortfolioEnv(
+        data_path=dummy_data,
+        lookback_window=10,
+        start_date="2020-03-01",
+        end_date="2020-05-01",
+    )
+    assert env.valid_start_idx > 10
+    assert env.valid_end_idx < 199
+
+
+def test_risk_bonus_weight_zero(dummy_data):
+    """With risk_bonus_weight=0, reward should be pure return * scaling."""
+    env = PortfolioEnv(
+        data_path=dummy_data, lookback_window=10, risk_bonus_weight=0.0
+    )
+    obs, _ = env.reset()
+    for _ in range(25):
+        action = np.ones(env.action_space.shape[0])
+        obs, reward, done, _, _ = env.step(action)
+        if done:
+            break
+
+
+def test_sentiment_observation(dummy_data_with_sentiment):
+    """Sentiment columns should add an extra feature per asset."""
+    env_no_sent = PortfolioEnv(
+        data_path=dummy_data_with_sentiment, lookback_window=10, use_sentiment=False
+    )
+    env_sent = PortfolioEnv(
+        data_path=dummy_data_with_sentiment, lookback_window=10, use_sentiment=True
+    )
+    assert env_sent.n_features_per_asset == env_no_sent.n_features_per_asset + 1
+    assert env_sent.observation_space.shape[0] > env_no_sent.observation_space.shape[0]
+    assert env_sent.has_sentiment is True
+
+
+def test_observation_clipping(dummy_data):
+    """When normalize_observations=True, obs should be clipped to [-10, 10]."""
+    env = PortfolioEnv(
+        data_path=dummy_data, lookback_window=10, normalize_observations=True
+    )
+    obs, _ = env.reset()
+    assert obs.max() <= 10.0
+    assert obs.min() >= -10.0

--- a/tests/test_train_ppo_integration.py
+++ b/tests/test_train_ppo_integration.py
@@ -8,6 +8,7 @@ from stable_baselines3.common.evaluation import evaluate_policy
 
 from src.rl_agent.train_ppo import PortfolioTrainer
 
+
 @pytest.mark.integration
 def test_training_runs_and_saves(tmp_path):
     """
@@ -17,18 +18,18 @@ def test_training_runs_and_saves(tmp_path):
     - Saves model + config + stats
     - Reloads model and evaluates
     """
-    # --- Setup ---
-    data_path = "data/sample/data_ppo_sample.parquet" 
-    trainer = PortfolioTrainer(
-        config_path=None,
-        data_path=data_path
-    )
+    data_path = "data/sample/data_ppo_sample.parquet"
+    trainer = PortfolioTrainer(config_path=None, data_path=data_path)
 
     # Override config for short test
     trainer.config["training"]["total_timesteps"] = 500
     trainer.config["training"]["n_envs"] = 1
+    trainer.config["training"]["n_steps"] = 128
     trainer.config["saving"]["save_freq"] = 0
     trainer.config["evaluation"]["eval_freq"] = 0
+    # Disable split dates (sample data is too small for date-based splits)
+    trainer.config["split"]["train_end_date"] = None
+    trainer.config["split"]["test_start_date"] = None
 
     # Redirect output dirs to tmp_path
     trainer.model_dir = tmp_path / "models"
@@ -37,10 +38,10 @@ def test_training_runs_and_saves(tmp_path):
     for d in [trainer.model_dir, trainer.log_dir, trainer.results_dir]:
         d.mkdir(parents=True, exist_ok=True)
 
-    # --- Train ---
+    # Train
     model = trainer.train()
 
-    # --- Assertions ---
+    # Assertions
     final_model_path = trainer.model_dir / "final_model.zip"
     assert final_model_path.exists(), "Final model not saved"
 
@@ -50,26 +51,28 @@ def test_training_runs_and_saves(tmp_path):
     stats_path = trainer.results_dir / "training_stats.json"
     assert stats_path.exists(), "Training stats not saved"
 
-    # --- Reload and evaluate ---
+    # Reload and evaluate
     loaded_model = PPO.load(final_model_path, env=trainer.create_vec_env())
-    mean_reward, std_reward = evaluate_policy(loaded_model, trainer.create_vec_env(), n_eval_episodes=1)
-
+    mean_reward, std_reward = evaluate_policy(
+        loaded_model, trainer.create_vec_env(), n_eval_episodes=1
+    )
     assert isinstance(mean_reward, float)
     assert not np.isnan(mean_reward)
 
 
 @pytest.mark.integration
 def test_predict_after_training(tmp_path):
-    """
-    Ensure trained PPO model can predict valid actions.
-    """
+    """Ensure trained PPO model can predict valid actions."""
     data_path = "data/sample/data_ppo_sample.parquet"
     trainer = PortfolioTrainer(data_path=data_path)
 
     trainer.config["training"]["total_timesteps"] = 300
     trainer.config["training"]["n_envs"] = 1
+    trainer.config["training"]["n_steps"] = 128
     trainer.config["saving"]["save_freq"] = 0
     trainer.config["evaluation"]["eval_freq"] = 0
+    trainer.config["split"]["train_end_date"] = None
+    trainer.config["split"]["test_start_date"] = None
 
     trainer.model_dir = tmp_path / "models"
     trainer.log_dir = tmp_path / "logs"
@@ -85,4 +88,3 @@ def test_predict_after_training(tmp_path):
 
     assert action.shape[-1] == env.action_space.shape[0]
     assert np.all(np.isfinite(action)), "Model produced invalid actions"
-


### PR DESCRIPTION
Major methodological and architectural improvements:

1. Environment (portfolio_env.py):
   - Add temporal train/test split via start_date/end_date and start_idx/end_idx
   - Switch from arithmetic returns (pct_change) to log returns
   - Fix dead code (unreachable normalization block)
   - Make risk bonus configurable (risk_bonus_weight, default 0 = pure return)
   - Add sentiment feature support (use_sentiment flag reads Sentiment_* columns)
   - Use equal-weight market proxy for correlation instead of first asset

2. Policy architectures (custom_policies.py):
   - CNN extractor: 1D conv over (lookback x assets*features) temporal tensor
   - LSTM extractor: recurrent processing of lookback sequence
   - Configurable via policy.type in YAML config (mlp/cnn/lstm)

3. Classical baselines (baselines.py):
   - Equal-weight (daily and monthly rebalance)
   - Buy-and-hold
   - Inverse-volatility (risk parity proxy)
   - Full metrics: Sharpe, Sortino, Calmar, max drawdown

4. Sentiment extraction (src/sentiment/extract_sentiment.py):
   - CamemBERT pipeline for French text sentiment
   - FinBERT fallback for English financial text
   - CLI with score and dummy subcommands
   - Trainer merges sentiment CSV into Sentiment_{ticker} columns

5. Training (train_ppo.py):
   - Train/test split support via config
   - Policy architecture selection
   - Multi-seed training via --seeds flag
   - Cleaner sentiment merge (pivot to wide format)

